### PR TITLE
html

### DIFF
--- a/core/interface/views/SnipswatchView.py
+++ b/core/interface/views/SnipswatchView.py
@@ -8,8 +8,6 @@ from core.base.SuperManager import SuperManager
 from core.commons import commons
 from core.interface.views.View import View
 
-from ansi2html import Ansi2HTMLConverter
-
 
 class SnipswatchView(View):
 
@@ -33,8 +31,7 @@ class SnipswatchView(View):
 
 
 	def startWatching(self):
-		process = subprocess.Popen('snips-watch -vv', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-		conv = Ansi2HTMLConverter()
+		process = subprocess.Popen('snips-watch -vv --html', shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
 		flag = SuperManager.getInstance().threadManager.newLock('running')
 		flag.set()
@@ -42,11 +39,8 @@ class SnipswatchView(View):
 			out = process.stdout.readline().decode()
 			if out != '':
 				with self._file.open('a+') as fp:
-					#line = commons.ansiToHtml(out)
-					line = commons.escapeAnsi(out)
-					line = self._importantColoring.sub('<span class="logYellow">\\1</span>', line)
-					line = self._intentColoring.sub('<span class="logYellow">\\1</span>', line)
-					line = self._timeColoring.sub('<span class="logYellow">\\1</span>', line)
+					line = out.replace('#009900', '"yellow"')
+					line = out.replace('#0000ff', '"yellow"')
 					fp.write(line)
 
 


### PR DESCRIPTION
snips-watch has a --html flag, however that does not really differ in colors.
So maybe we should instead use --no-color and decide for a completely own color model.