### PR TITLE
add anyExcept decorator

### DIFF
--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, Tuple
 
 import warnings
 

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -104,7 +104,7 @@ class Decorators:
 	
 
 	@classmethod
-	def anyExcept(cls, text: str = '', exceptions: Tuple[BaseException, ...] = None, exceptHandler: Callable = None, returnText: bool = False):
+	def anyExcept(cls, text: str = '', exceptions: Tuple[BaseException, ...] = None, exceptHandler: Callable = None, returnText: bool = False, printStack=False):
 		def _exceptHandler(*args, **kwargs):
 			nonlocal text
 
@@ -129,7 +129,7 @@ class Decorators:
 				try:
 					return func(*args, **kwargs)
 				except exceptions as e:
-					Logger(depth=6).logWarning(e)
+					Logger(depth=6).logWarning(msg=e, printStack=printStack)
 					return _exceptHandler(*args, **kwargs)
 
 			return functionWrapper

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -86,7 +86,7 @@ class Decorators:
 
 		def argumentWrapper(func):
 			@wraps(func)
-			def functionWrapper(*args, **kwargs):
+			def offlineDecorator(*args, **kwargs):
 				internetManager = SuperManager.getInstance().internetManager
 				if internetManager.online:
 					try:
@@ -98,13 +98,14 @@ class Decorators:
 
 				return _offlineHandler(*args, **kwargs)
 
-			return functionWrapper
+			return offlineDecorator
 
 		return argumentWrapper(text) if callable(text) else argumentWrapper
 	
 
 	@classmethod
-	def anyExcept(cls, text: str = '', exceptions: Tuple[BaseException, ...] = None, exceptHandler: Callable = None, returnText: bool = False, printStack=False):
+	def anyExcept(cls, text: str = '', exceptions: Tuple[BaseException, ...] = None, exceptHandler: Callable = None, returnText: bool = False, printStack: bool = False):
+		
 		def _exceptHandler(*args, **kwargs):
 			nonlocal text
 
@@ -125,14 +126,14 @@ class Decorators:
 
 		def argumentWrapper(func):
 			@wraps(func)
-			def functionWrapper(*args, **kwargs):
+			def exceptionDecorator(*args, **kwargs):
 				try:
 					return func(*args, **kwargs)
 				except exceptions as e:
 					Logger(depth=6).logWarning(msg=e, printStack=printStack)
 					return _exceptHandler(*args, **kwargs)
 
-			return functionWrapper
+			return exceptionDecorator
 
 		exceptions = exceptions or Exception
 		return argumentWrapper(text) if callable(text) else argumentWrapper

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -7,6 +7,7 @@ from functools import wraps
 from core.base.model.Module import Module
 from core.dialog.model.DialogSession import DialogSession
 from core.base.SuperManager import SuperManager
+from core.util.model.Logger import Logger
 
 
 class Decorators:
@@ -19,7 +20,6 @@ class Decorators:
 		as deprecated. It will result in a warning being emitted
 		when the function is used.
 		"""
-
 
 		@wraps(func)
 		def new_func(*args, **kwargs):
@@ -68,10 +68,11 @@ class Decorators:
 		"""
 		def _offlineHandler(*args, **kwargs):
 			nonlocal text
-			caller = args[0] if args and isinstance(args[0], Module) else None
 
 			if offlineHandler:
 				return offlineHandler(*args, **kwargs)
+			
+			caller = args[0] if args and isinstance(args[0], Module) else None
 
 			if callable(text) or not text:
 				text = SuperManager.getInstance().talkManager.randomTalk('offline', module='system')
@@ -99,4 +100,39 @@ class Decorators:
 
 			return functionWrapper
 
+		return argumentWrapper(text) if callable(text) else argumentWrapper
+	
+
+	@classmethod
+	def anyExcept(cls, text: str = '', exceptions: Tuple[BaseException, ...] = None, exceptHandler: Callable = None, returnText: bool = False):
+		def _exceptHandler(*args, **kwargs):
+			nonlocal text
+
+			if exceptHandler:
+				return exceptHandler(*args, **kwargs)
+			
+			caller = args[0] if args and isinstance(args[0], Module) else None
+
+			if callable(text) or not text:
+				text = SuperManager.getInstance().talkManager.randomTalk('except', module='system')
+			elif hasattr(caller, 'name'):
+				text = SuperManager.getInstance().talkManager.randomTalk(text, module=caller.name)
+
+			session = kwargs.get('session')
+			if not returnText and isinstance(session, DialogSession):
+				SuperManager.getInstance().mqttManager.endDialog(sessionId=session.sessionId, text=text)
+			return text
+
+		def argumentWrapper(func):
+			@wraps(func)
+			def functionWrapper(*args, **kwargs):
+				try:
+					return func(*args, **kwargs)
+				except exceptions as e:
+					Logger(depth=6).logWarning(e)
+					return _exceptHandler(*args, **kwargs)
+
+			return functionWrapper
+
+		exceptions = exceptions or Exception
 		return argumentWrapper(text) if callable(text) else argumentWrapper

--- a/core/util/model/Logger.py
+++ b/core/util/model/Logger.py
@@ -25,8 +25,8 @@ class Logger:
 		self.doLog(function='fatal', msg=msg)
 
 
-	def logWarning(self, msg: str):
-		self.doLog(function='warning', msg=msg, printStack=False)
+	def logWarning(self, msg: str, printStack: bool = False):
+		self.doLog(function='warning', msg=msg, printStack=printStack)
 
 
 	def logCritical(self, msg: str):

--- a/system/manager/TalkManager/talks/de.json
+++ b/system/manager/TalkManager/talks/de.json
@@ -79,5 +79,8 @@
 	],
 	"offline": [
 		"Entschuldigung, das kann ich nicht machen wenn ich offline bin."
+	],
+	"except": [
+		"Entschuldigung, beim Ausführen deines Wunsches ist ein Fehler augetreten"
 	]
 }

--- a/system/manager/TalkManager/talks/en.json
+++ b/system/manager/TalkManager/talks/en.json
@@ -80,6 +80,6 @@
 		"I'm sorry but I can't do that while being offline"
 	],
 	"except": [
-		"I am sorry but a exception occured while executing this intent"
+		"I am sorry but an exception occured while executing this intent"
 	]
 }

--- a/system/manager/TalkManager/talks/en.json
+++ b/system/manager/TalkManager/talks/en.json
@@ -78,5 +78,8 @@
 	],
 	"offline": [
 		"I'm sorry but I can't do that while being offline"
+	],
+	"except": [
+		"I am sorry but a exception occured while executing this intent"
 	]
 }


### PR DESCRIPTION
right now you have the option to write
```
@Decorators.online
def func():
    try:
   except Exception:
```

however then the online decorator can not check whether it is offline and output the corresponding message
so it has to be written as

```
def func1():
    try:
       func()
   except Exception:

@Decorators.online
def func():
```

which gets kind of ugly especially when you have many intents that need this kind of exception handling.

With this decorator you can now write

```
@Decorator.anyExcept
@Decorators.online
def func():
```
by default it acts pretty much as the online decorator, just that it reacts to any exceptions. As with the online decorator by default it calls endDialog (when session is in kwargs), but a different exceptHandler can be used.
Since it is not always wanted to catch all exceptions the default is Exception but it is possible to provide a tuple of exceptions to catch aswell

***not tested yet and the default answer is not added to the system talk file yet and the docstring is still missing aswell***
