### PR TITLE
add intent decorator

### DIFF
--- a/core/base/model/Intent.py
+++ b/core/base/model/Intent.py
@@ -82,8 +82,8 @@ class Intent(str, ProjectAliceObject):
 	@dialogMapping.setter
 	def dialogMapping(self, value: Dict[str, Callable]):
 		self._dialogMapping = DialogMapping(value)
-	
-	
+
+
 	def addDialogMapping(self, value: Dict[str, Callable]):
 		if self._dialogMapping:
 			self._dialogMapping.addMappings(value)

--- a/core/base/model/Intent.py
+++ b/core/base/model/Intent.py
@@ -82,3 +82,10 @@ class Intent(str, ProjectAliceObject):
 	@dialogMapping.setter
 	def dialogMapping(self, value: Dict[str, Callable]):
 		self._dialogMapping = DialogMapping(value)
+	
+	
+	def addDialogMapping(self, value: Dict[str, Callable]):
+		if self._dialogMapping:
+			self._dialogMapping.addMappings(value)
+		else:
+			self._dialogMapping = DialogMapping(value)

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -23,7 +23,7 @@ from core.util.Decorators import IntentWrapper
 
 class Module(ProjectAliceObject):
 
-	def __init__(self, supportedIntents: Iterable, authOnlyIntents: dict = None, databaseSchema: dict = None):
+	def __init__(self, supportedIntents: Iterable = None, authOnlyIntents: dict = None, databaseSchema: dict = None):
 		super().__init__(logDepth=4)
 		try:
 			path = Path(inspect.getfile(self.__class__)).with_suffix('.install')
@@ -42,6 +42,9 @@ class Module(ProjectAliceObject):
 		self._required = False
 		self._databaseSchema = databaseSchema
 		self._widgets = dict()
+
+		if not supportedIntents:
+			supportedIntents = list()
 
 		self._myIntents: List[Intent] = list()
 		self._supportedIntents: Dict[str, Tuple[(str, Intent), Callable]] = dict()

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -19,7 +19,7 @@ from core.base.model.ProjectAliceObject import ProjectAliceObject
 from core.commons import constants
 from core.dialog.model.DialogSession import DialogSession
 from core.user.model.AccessLevels import AccessLevel
-from core.util.Decorators.Intent import IntentWrapper
+from core.util.Decorators import Decorators
 
 
 class Module(ProjectAliceObject):
@@ -49,7 +49,7 @@ class Module(ProjectAliceObject):
 
 		self._myIntents: List[Intent] = list()
 		self._supportedIntents: Dict[str, Tuple[(str, Intent), Callable]] = dict()
-		for item in [*supportedIntents, *self.intentMethods()]:
+		for item in (*supportedIntents, *self.intentMethods()):
 			if isinstance(item, tuple):
 				self._supportedIntents[str(item[0])] = item
 				self._myIntents.append(item[0])
@@ -65,10 +65,10 @@ class Module(ProjectAliceObject):
 
 
 	@classmethod
-	def decoratedIntentMethods(cls) -> Generator[IntentWrapper, None, None]:
+	def decoratedIntentMethods(cls) -> Generator[Decorators.Intent.Wrapper, None, None]:
 		for name in dir(cls):
 			method = getattr(cls, name)
-			while isinstance(method, IntentWrapper):
+			while isinstance(method, Decorators.Intent.Wrapper):
 				yield method
 				method = method.decoratedMethod
 
@@ -78,11 +78,11 @@ class Module(ProjectAliceObject):
 		intents = dict()
 		for method in cls.decoratedIntentMethods():
 			if not method.requiredState:
-				intents[method.intentName] = (method.intent(), method)
+				intents[method.intentName] = (method.intent, method)
 				continue
 
 			if method.intentName not in intents:
-				intents[method.intentName] = method.intent()
+				intents[method.intentName] = method.intent
 
 			intents[method.intentName].addDialogMapping({method.requiredState: method})
 

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -18,6 +18,7 @@ from core.base.model.ProjectAliceObject import ProjectAliceObject
 from core.commons import constants
 from core.dialog.model.DialogSession import DialogSession
 from core.user.model.AccessLevels import AccessLevel
+from core.util.Decorators import IntentWrapper
 
 
 class Module(ProjectAliceObject):
@@ -44,7 +45,7 @@ class Module(ProjectAliceObject):
 
 		self._myIntents: List[Intent] = list()
 		self._supportedIntents: Dict[str, Tuple[(str, Intent), Callable]] = dict()
-		for item in supportedIntents:
+		for item in (supportedIntents, self.intentMethods()):
 			if isinstance(item, tuple):
 				self._supportedIntents[str(item[0])] = item
 				self._myIntents.append(item[0])
@@ -57,6 +58,16 @@ class Module(ProjectAliceObject):
 		self._authOnlyIntents: Dict[str, AccessLevel] = {str(intent): level.value for intent, level in authOnlyIntents.items()} if authOnlyIntents else dict()
 		self._utteranceSlotCleaner = re.compile('{(.+?):=>.+?}')
 		self.loadWidgets()
+
+
+	@classmethod
+	def intentMethods(cls) -> list:
+		intents = list()
+		for name in dir(cls):
+			method = getattr(cls, name)
+			if isinstance(method, IntentWrapper):
+				intents.append((method.intent, method))
+		return intents
 
 
 	# noinspection SqlResolve

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -49,7 +49,7 @@ class Module(ProjectAliceObject):
 
 		self._myIntents: List[Intent] = list()
 		self._supportedIntents: Dict[str, Tuple[(str, Intent), Callable]] = dict()
-		for item in (supportedIntents, self.intentMethods()):
+		for item in [*supportedIntents, *self.intentMethods()]:
 			if isinstance(item, tuple):
 				self._supportedIntents[str(item[0])] = item
 				self._myIntents.append(item[0])
@@ -68,11 +68,9 @@ class Module(ProjectAliceObject):
 	def decoratedIntentMethods(cls) -> Generator[IntentWrapper, None, None]:
 		for name in dir(cls):
 			method = getattr(cls, name)
-			if isinstance(method, functools.partial):
-				method = method.func
-				while isinstance(method, IntentWrapper):
-					yield method
-					method = method.decoratedMethod
+			while isinstance(method, IntentWrapper):
+				yield method
+				method = method.decoratedMethod
 
 
 	@classmethod

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -70,10 +70,10 @@ class Module(ProjectAliceObject):
 			method = getattr(cls, name)
 			if isinstance(method, IntentWrapper):
 				if not method.requiredState:
-					intents[method.intent] = (Intent(method.intent), method)
+					intents[method.intent] = (Intent(method.intent, isProtected=method.isProtected, userIntent=method.userIntent), method)
 					continue
 				if method.intent not in intents:
-					intents[method.intent] = Intent(method.intent)
+					intents[method.intent] = Intent(method.intent, isProtected=method.isProtected, userIntent=method.userIntent)
 
 				intents[method.intent].addDialogMapping({method.requiredState: method})
 		

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -4,6 +4,7 @@ import importlib
 import inspect
 import json
 import sqlite3
+import functools
 
 import re
 
@@ -68,7 +69,8 @@ class Module(ProjectAliceObject):
 		intents = dict()
 		for name in dir(cls):
 			method = getattr(cls, name)
-			if isinstance(method, IntentWrapper):
+			if isinstance(method, functools.partial) and isinstance(method.func, IntentWrapper):
+				method = method.func
 				if not method.requiredState:
 					intents[method.intent] = (Intent(method.intent, isProtected=method.isProtected, userIntent=method.userIntent), method)
 					continue

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -69,15 +69,17 @@ class Module(ProjectAliceObject):
 		intents = dict()
 		for name in dir(cls):
 			method = getattr(cls, name)
-			if isinstance(method, functools.partial) and isinstance(method.func, IntentWrapper):
+			if isinstance(method, functools.partial):
 				method = method.func
-				if not method.requiredState:
-					intents[method.intent] = (Intent(method.intent, isProtected=method.isProtected, userIntent=method.userIntent), method)
-					continue
-				if method.intent not in intents:
-					intents[method.intent] = Intent(method.intent, isProtected=method.isProtected, userIntent=method.userIntent)
+				while isinstance(method, IntentWrapper):
+					if not method.requiredState:
+						intents[method.intent] = (Intent(method.intent, isProtected=method.isProtected, userIntent=method.userIntent), method)
+					else:
+						if method.intent not in intents:
+							intents[method.intent] = Intent(method.intent, isProtected=method.isProtected, userIntent=method.userIntent)
 
-				intents[method.intent].addDialogMapping({method.requiredState: method})
+						intents[method.intent].addDialogMapping({method.requiredState: method})
+					method = method.decoratedMethod
 		
 		return list(intents.values())
 

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -19,7 +19,7 @@ from core.base.model.ProjectAliceObject import ProjectAliceObject
 from core.commons import constants
 from core.dialog.model.DialogSession import DialogSession
 from core.user.model.AccessLevels import AccessLevel
-from core.util.Decorators import Decorators
+from core.util.Decorators import IntentHandler
 
 
 class Module(ProjectAliceObject):
@@ -65,10 +65,10 @@ class Module(ProjectAliceObject):
 
 
 	@classmethod
-	def decoratedIntentMethods(cls) -> Generator[Decorators.Intent.Wrapper, None, None]:
+	def decoratedIntentMethods(cls) -> Generator[IntentHandler.Wrapper, None, None]:
 		for name in dir(cls):
 			method = getattr(cls, name)
-			while isinstance(method, Decorators.Intent.Wrapper):
+			while isinstance(method, IntentHandler.Wrapper):
 				yield method
 				method = method.decoratedMethod
 

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -4,7 +4,6 @@ import importlib
 import inspect
 import json
 import sqlite3
-import functools
 
 import re
 

--- a/core/base/model/Module.py
+++ b/core/base/model/Module.py
@@ -18,7 +18,7 @@ from core.base.model.ProjectAliceObject import ProjectAliceObject
 from core.commons import constants
 from core.dialog.model.DialogSession import DialogSession
 from core.user.model.AccessLevels import AccessLevel
-from core.util.Decorators import IntentWrapper
+from core.util.Decorators.Intent import IntentWrapper
 
 
 class Module(ProjectAliceObject):
@@ -65,12 +65,19 @@ class Module(ProjectAliceObject):
 
 	@classmethod
 	def intentMethods(cls) -> list:
-		intents = list()
+		intents = dict()
 		for name in dir(cls):
 			method = getattr(cls, name)
 			if isinstance(method, IntentWrapper):
-				intents.append((method.intent, method))
-		return intents
+				if not method.requiredState:
+					intents[method.intent] = (Intent(method.intent), method)
+					continue
+				if method.intent not in intents:
+					intents[method.intent] = Intent(method.intent)
+
+				intents[method.intent].addDialogMapping({method.requiredState: method})
+		
+		return list(intents.values())
 
 
 	# noinspection SqlResolve

--- a/core/dialog/model/DialogMapping.py
+++ b/core/dialog/model/DialogMapping.py
@@ -26,6 +26,10 @@ class DialogMapping(ProjectAliceObject):
 		return False
 
 
+	def addMappings(self, mapping: Dict[str, Callable]):
+		caller = self.Commons.getFunctionCaller()
+		self._mapping.update({f'{caller}:{state}': func for state, func in mapping.items()})
+
 	@property
 	def state(self) -> str:
 		return self._state

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -147,22 +147,30 @@ class Decorators:
 
 
 	class Intent:
-		def __init__(self, intentName: str):
+		class IntentWrapper:
+			def __init__(self, intentName: str, method: Callable, requiredState: str = None):
+				self._method = method
+				self._intent = intentName
+				self._requiredState = requiredState
+
+			def __call__(self, *args, **kwargs):
+				return self._method(*args, **kwargs)
+
+			@property
+			def intent(self) -> str:
+				return self._intent
+
+			@property
+			def requiredState(self) -> str:
+				return self._requiredState
+
+		def __init__(self, intentName: str, requiredState: str = None):
 			self._intentName = intentName
+			self._requiredState = requiredState
 
 		def __call__(self, func: Callable):
-			return IntentWrapper(self._intentName, func)
+			return self.IntentWrapper(self._intentName, func, self._requiredState)
 
 
 
-class IntentWrapper:
-	def __init__(self, intentName: str, method: Callable):
-		self._method = method
-		self._intent = Intent(intentName)
 
-	def __call__(self, *args, **kwargs):
-		return self._method(*args, **kwargs)
-
-	@property
-	def intent(self):
-		return self._intent

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -8,6 +8,7 @@ from core.base.model.Module import Module
 from core.dialog.model.DialogSession import DialogSession
 from core.base.SuperManager import SuperManager
 from core.util.model.Logger import Logger
+from core.base.model.Intent import Intent
 
 
 class Decorators:
@@ -143,3 +144,25 @@ class Decorators:
 
 		exceptions = exceptions or Exception
 		return argumentWrapper(text) if callable(text) else argumentWrapper
+
+
+	class Intent:
+		def __init__(self, intentName: str):
+			self._intentName = intentName
+
+		def __call__(self, func: Callable):
+			return IntentWrapper(self._intentName, func)
+
+
+
+class IntentWrapper:
+	def __init__(self, intentName: str, method: Callable):
+		self._method = method
+		self._intent = Intent(intentName)
+
+	def __call__(self, *args, **kwargs):
+		return self._method(*args, **kwargs)
+
+	@property
+	def intent(self):
+		return self._intent

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -2,7 +2,7 @@ from typing import Callable, Tuple
 
 import warnings
 
-from functools import wraps
+from functools import wraps, partial
 
 from core.base.model.Module import Module
 from core.dialog.model.DialogSession import DialogSession
@@ -154,8 +154,11 @@ class Decorators:
 				self.userIntent = userIntent
 				self._method = method
 
-			def __call__(self, *args, **kwargs):
-				return self._method(*args, **kwargs)
+			def __call__(self, instance, *args, **kwargs):
+				return self._method(instance, *args, **kwargs)
+		
+			def __get__(self, instance, owner):
+				return partial(self, instance)
 
 		def __init__(self, intentName: str, requiredState: str = None, isProtected: bool = False, userIntent: bool = True):
 			self._intentName = intentName

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -171,7 +171,18 @@ class Decorators:
 				request = requests.get('http://api.open-notify.org')
 				self.endDialog(sessionId=session.sessionId, text=request.text)
 			
-			In the same way all other parameters supported by the Intent class can be used in the decorator
+			In the same way all other parameters supported by the Intent class can be used in the decorator.
+
+
+			Mapping multiple intents to the same function is possible aswell using
+			(make sure that the intent decorators are used in front of any other decorators):
+
+			@Intent('intentName1')
+			@Intent('intentName2')
+			def exampleIntent(self, session: DialogSession, **_kwargs):
+				request = requests.get('http://api.open-notify.org')
+				self.endDialog(sessionId=session.sessionId, text=request.text)
+
 		"""
 		class IntentWrapper:
 			def __init__(self, intentName: str, requiredState: str, isProtected: bool, userIntent: bool, method: Callable):
@@ -179,10 +190,10 @@ class Decorators:
 				self.requiredState = requiredState
 				self.isProtected = isProtected
 				self.userIntent = userIntent
-				self._method = method
+				self.decoratedMethod = method
 
 			def __call__(self, instance, *args, **kwargs):
-				return self._method(instance, *args, **kwargs)
+				return self.decoratedMethod(instance, *args, **kwargs)
 		
 			def __get__(self, instance, owner):
 				return partial(self, instance)

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -1,8 +1,8 @@
-from typing import Callable, Tuple
+from typing import Callable, Tuple, Any
 
 import warnings
 
-from functools import wraps
+import functools
 
 from core.base.model.Module import Module
 from core.dialog.model.DialogSession import DialogSession
@@ -22,7 +22,7 @@ class Decorators:
 		when the function is used.
 		"""
 
-		@wraps(func)
+		@functools.wraps(func)
 		def new_func(*args, **kwargs):
 			warnings.simplefilter('always', DeprecationWarning)  # turn off filter
 			warnings.warn(f'Call to deprecated function {func.__name__}.',
@@ -89,7 +89,7 @@ class Decorators:
 			return text
 
 		def argumentWrapper(func):
-			@wraps(func)
+			@functools.wraps(func)
 			def offlineDecorator(*args, **kwargs):
 				internetManager = SuperManager.getInstance().internetManager
 				if internetManager.online:
@@ -132,7 +132,7 @@ class Decorators:
 			return text
 
 		def argumentWrapper(func):
-			@wraps(func)
+			@functools.wraps(func)
 			def exceptionDecorator(*args, **kwargs):
 				try:
 					return func(*args, **kwargs)
@@ -192,9 +192,10 @@ class IntentHandler:
 			self._isProtected = isProtected
 			self._userIntent = userIntent
 			self._owner = None
+			functools.update_wrapper(self, method, updated=[])
 
 		@property
-		def intent(self):
+		def intent(self) -> Intent:
 			return Intent(self.intentName, isProtected=self._isProtected, userIntent=self._userIntent)
 
 		def __call__(self, *args, **kwargs):
@@ -211,7 +212,7 @@ class IntentHandler:
 		self._isProtected = isProtected
 		self._userIntent = userIntent
 
-	def __call__(self, func: Callable):
+	def __call__(self, func: Callable) -> IntentHandler.Wrapper:
 		return self.Wrapper(func, self._intentName, self._requiredState, self._isProtected, self._userIntent)
 
 

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -8,6 +8,7 @@ from core.base.model.Module import Module
 from core.dialog.model.DialogSession import DialogSession
 from core.base.SuperManager import SuperManager
 from core.util.model.Logger import Logger
+from core.base.model.Intent import Intent as IntentObject
 
 
 class Decorators:
@@ -149,7 +150,7 @@ class Decorators:
 		"""
 		(return a) decorator to mark a function as an intent.
 
-		This decorator can be used to map a function to a intent. 
+		This decorator can be used to map a function to a intent.
 
 		:param intentName:
 		:param requiredState:
@@ -163,14 +164,14 @@ class Decorators:
 			def exampleIntent(self, session: DialogSession, **_kwargs):
 				request = requests.get('http://api.open-notify.org')
 				self.endDialog(sessionId=session.sessionId, text=request.text)
-			
+
 			When the function should only be called when the current dialogState is 'currentState':
 
 			@Intent('intentName', requiredState='currentState')
 			def exampleIntent(self, session: DialogSession, **_kwargs):
 				request = requests.get('http://api.open-notify.org')
 				self.endDialog(sessionId=session.sessionId, text=request.text)
-			
+
 			In the same way all other parameters supported by the Intent class can be used in the decorator.
 
 
@@ -182,19 +183,21 @@ class Decorators:
 			def exampleIntent(self, session: DialogSession, **_kwargs):
 				request = requests.get('http://api.open-notify.org')
 				self.endDialog(sessionId=session.sessionId, text=request.text)
-
 		"""
 		class IntentWrapper:
 			def __init__(self, intentName: str, requiredState: str, isProtected: bool, userIntent: bool, method: Callable):
-				self.intent = intentName
+				self.intentName = intentName
 				self.requiredState = requiredState
 				self.isProtected = isProtected
 				self.userIntent = userIntent
 				self.decoratedMethod = method
 
+			def intent(self):
+				return IntentObject(self.intentName, isProtected=self.isProtected, userIntent=self.userIntent)
+
 			def __call__(self, instance, *args, **kwargs):
 				return self.decoratedMethod(instance, *args, **kwargs)
-		
+
 			def __get__(self, instance, owner):
 				return partial(self, instance)
 

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -8,7 +8,6 @@ from core.base.model.Module import Module
 from core.dialog.model.DialogSession import DialogSession
 from core.base.SuperManager import SuperManager
 from core.util.model.Logger import Logger
-from core.base.model.Intent import Intent
 
 
 class Decorators:
@@ -148,28 +147,24 @@ class Decorators:
 
 	class Intent:
 		class IntentWrapper:
-			def __init__(self, intentName: str, method: Callable, requiredState: str = None):
+			def __init__(self, intentName: str, requiredState: str, isProtected: bool, userIntent: bool, method: Callable):
+				self.intent = intentName
+				self.requiredState = requiredState
+				self.isProtected = isProtected
+				self.userIntent = userIntent
 				self._method = method
-				self._intent = intentName
-				self._requiredState = requiredState
 
 			def __call__(self, *args, **kwargs):
 				return self._method(*args, **kwargs)
 
-			@property
-			def intent(self) -> str:
-				return self._intent
-
-			@property
-			def requiredState(self) -> str:
-				return self._requiredState
-
-		def __init__(self, intentName: str, requiredState: str = None):
+		def __init__(self, intentName: str, requiredState: str = None, isProtected: bool = False, userIntent: bool = True):
 			self._intentName = intentName
 			self._requiredState = requiredState
+			self._isProtected = isProtected
+			self._userIntent = userIntent
 
 		def __call__(self, func: Callable):
-			return self.IntentWrapper(self._intentName, func, self._requiredState)
+			return self.IntentWrapper(self._intentName, func, self._requiredState, self._isProtected, self._userIntent)
 
 
 

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -195,11 +195,12 @@ class Decorators:
 			def intent(self):
 				return IntentObject(self.intentName, isProtected=self.isProtected, userIntent=self.userIntent)
 
-			def __call__(self, instance, *args, **kwargs):
-				return self.decoratedMethod(instance, *args, **kwargs)
+			def __call__(self, *args, **kwargs):
+				return self.decoratedMethod(self._instance, *args, **kwargs)
 
 			def __get__(self, instance, owner):
-				return partial(self, instance)
+				self._instance = instance
+				return self
 
 		def __init__(self, intentName: str, requiredState: str = None, isProtected: bool = False, userIntent: bool = True):
 			self._intentName = intentName

--- a/core/util/Decorators.py
+++ b/core/util/Decorators.py
@@ -146,6 +146,33 @@ class Decorators:
 
 
 	class Intent:
+		"""
+		(return a) decorator to mark a function as an intent.
+
+		This decorator can be used to map a function to a intent. 
+
+		:param intentName:
+		:param requiredState:
+		:param isProtected:
+		:param userIntent:
+		:return: return value of the decorated function
+		Examples:
+			An intent handler can be mapped to the intent 'intentName' the following way:
+
+			@Intent('intentName')
+			def exampleIntent(self, session: DialogSession, **_kwargs):
+				request = requests.get('http://api.open-notify.org')
+				self.endDialog(sessionId=session.sessionId, text=request.text)
+			
+			When the function should only be called when the current dialogState is 'currentState':
+
+			@Intent('intentName', requiredState='currentState')
+			def exampleIntent(self, session: DialogSession, **_kwargs):
+				request = requests.get('http://api.open-notify.org')
+				self.endDialog(sessionId=session.sessionId, text=request.text)
+			
+			In the same way all other parameters supported by the Intent class can be used in the decorator
+		"""
 		class IntentWrapper:
 			def __init__(self, intentName: str, requiredState: str, isProtected: bool, userIntent: bool, method: Callable):
 				self.intent = intentName


### PR DESCRIPTION
I did not test this yet, but this should allow for even shorter module code e.g. my Speedtest module thats currently:
```python
import speedtest
from speedtest import SpeedtestException

from core.base.model.Intent import Intent
from core.base.model.Module import Module
from core.dialog.model.DialogSession import DialogSession
from core.util.Decorators import Decorators

class Speedtest(Module):
	"""
	Author: maxbachmann
	Description: run internet speed test
	"""

	_INTENT_SPEEDTEST = Intent('Speedtest')

	def __init__(self):
		self._INTENTS = [
			(self._INTENT_SPEEDTEST, self.runSpeedtest)
		]

		super().__init__(self._INTENTS)


	@Decorators.online
	def runSpeedtest(self, session: DialogSession, **_kwargs):
		self.ThreadManager.doLater(interval=0, func=self.executeSpeedtest, kwargs={'session': session})
		self.logInfo('Starting Speedtest')
		self.endDialog(sessionId=session.sessionId, text=self.randomTalk('running'))


	@Decorators.anyExcept(exceptions=(SpeedtestException, KeyError), text='failed', printStack=True)
	@Decorators.online
	def executeSpeedtest(self, session: DialogSession):
		speed = speedtest.Speedtest()
		speed.get_servers()
		speed.get_best_server()
		speed.download()
		speed.upload(pre_allocate=False)
		speed.results.share()
		result = speed.results.dict()
		downspeed = '{:.2f}'.format(result['download']/1000000)
		upspeed = '{:.2f}'.format(result['upload']/1000000)
		self.logInfo(f'Download speed: {downspeed} Mbps, Upload speed: {upspeed} Mbps')
		self.say(text=self.randomTalk(text='result', replace=[downspeed, upspeed]), siteId=session.siteId)
```
would become
```python
import speedtest
from speedtest import SpeedtestException

from core.base.model.Module import Module
from core.dialog.model.DialogSession import DialogSession
from core.util.Decorators import Decorators

class Speedtest(Module):
	"""
	Author: maxbachmann
	Description: run internet speed test
	"""

	@Decorators.Intent('Speedtest')
	@Decorators.online
	def runSpeedtest(self, session: DialogSession, **_kwargs):
		self.ThreadManager.doLater(interval=0, func=self.executeSpeedtest, kwargs={'session': session})
		self.logInfo('Starting Speedtest')
		self.endDialog(sessionId=session.sessionId, text=self.randomTalk('running'))


	@Decorators.anyExcept(exceptions=(SpeedtestException, KeyError), text='failed', printStack=True)
	@Decorators.online
	def executeSpeedtest(self, session: DialogSession):
		speed = speedtest.Speedtest()
		speed.get_servers()
		speed.get_best_server()
		speed.download()
		speed.upload(pre_allocate=False)
		speed.results.share()
		result = speed.results.dict()
		downspeed = '{:.2f}'.format(result['download']/1000000)
		upspeed = '{:.2f}'.format(result['upload']/1000000)
		self.logInfo(f'Download speed: {downspeed} Mbps, Upload speed: {upspeed} Mbps')
		self.say(text=self.randomTalk(text='result', replace=[downspeed, upspeed]), siteId=session.siteId)
```
Right now this can be combined with the old syntax, but when defining the same intent with dialog mappings in the old syntax it will be overridden by the decorator, so for each intent that uses dialog mappings it is required to use the old syntax and for onMessage/other function direct mappings this decorator can be used.
However this can be extended do directly allow dialog mappings in there aswell 
e.g.
```python
@Decorators.Intent('exampleIntent', 'requiredState')
```